### PR TITLE
Changed scope separator to space for HubSpot

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -13,6 +13,13 @@ class Provider extends AbstractProvider
     const IDENTIFIER = 'HUBSPOT';
 
     /**
+     * The separating character for the requested scopes.
+     *
+     * @var string
+     */
+    protected $scopeSeparator = ' '; // HubSpot uses a space separator.
+
+    /**
      * {@inheritdoc}
      */
     protected function getAuthUrl($state)


### PR DESCRIPTION
HubSpot uses space as the separator:

https://developers.hubspot.com/docs/methods/oauth2/initiate-oauth-integration
